### PR TITLE
Set up an early version of the plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+eos-icons/node_modules

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # eos-icons-figma
+
 Figma extension for EOS-icons
+
+## Contributing
+
+- Follow the Figma plugin [prerequisites](https://www.figma.com/plugin-docs/prerequisites/) and [setup guide](https://www.figma.com/plugin-docs/setup/).
+- Open the create a plugin page and select `Link existing plugin`.
+- choose the `manifest.json` file from `eos-icons/manifest.json`.

--- a/eos-icons/README.md
+++ b/eos-icons/README.md
@@ -1,0 +1,40 @@
+Below are the steps to get your plugin running. You can also find instructions at:
+
+  https://www.figma.com/plugin-docs/setup/
+
+This plugin template uses Typescript and NPM, two standard tools in creating JavaScript applications.
+
+First, download Node.js which comes with NPM. This will allow you to install TypeScript and other
+libraries. You can find the download link here:
+
+  https://nodejs.org/en/download/
+
+Next, install TypeScript using the command:
+
+  npm install -g typescript
+
+Finally, in the directory of your plugin, get the latest type definitions for the plugin API by running:
+
+  npm install --save-dev @figma/plugin-typings
+
+If you are familiar with JavaScript, TypeScript will look very familiar. In fact, valid JavaScript code
+is already valid Typescript code.
+
+TypeScript adds type annotations to variables. This allows code editors such as Visual Studio Code
+to provide information about the Figma API while you are writing code, as well as help catch bugs
+you previously didn't notice.
+
+For more information, visit https://www.typescriptlang.org/
+
+Using TypeScript requires a compiler to convert TypeScript (code.ts) into JavaScript (code.js)
+for the browser to run.
+
+We recommend writing TypeScript code using Visual Studio code:
+
+1. Download Visual Studio Code if you haven't already: https://code.visualstudio.com/.
+2. Open this directory in Visual Studio Code.
+3. Compile TypeScript to JavaScript: Run the "Terminal > Run Build Task..." menu item,
+    then select "tsc: watch - tsconfig.json". You will have to do this again every time
+    you reopen Visual Studio Code.
+
+That's it! Visual Studio Code will regenerate the JavaScript file every time you save.

--- a/eos-icons/code.js
+++ b/eos-icons/code.js
@@ -1,0 +1,18 @@
+figma.showUI(__html__);
+figma.ui.onmessage = (msg) => {
+    if (msg.type === "search-icons") {
+        figma.ui.postMessage({
+            type: "get-svg",
+            searchText: msg.searchText,
+        });
+    }
+    if (msg.type === "handle-icon") {
+        const nodes = [];
+        const icon = figma.createNodeFromSvg(msg.svg);
+        icon.rescale(3);
+        nodes.push(icon);
+        figma.currentPage.selection = nodes;
+        figma.viewport.scrollAndZoomIntoView(nodes);
+        figma.closePlugin();
+    }
+};

--- a/eos-icons/code.ts
+++ b/eos-icons/code.ts
@@ -1,0 +1,20 @@
+figma.showUI(__html__);
+
+figma.ui.onmessage = (msg) => {
+  if (msg.type === "search-icons") {
+    figma.ui.postMessage({
+      type: "get-svg",
+      searchText: msg.searchText,
+    });
+  }
+
+  if (msg.type === "handle-icon") {
+    const nodes: SceneNode[] = [];
+    const icon = figma.createNodeFromSvg(msg.svg);
+    icon.rescale(3);
+    nodes.push(icon);
+    figma.currentPage.selection = nodes;
+    figma.viewport.scrollAndZoomIntoView(nodes);
+    figma.closePlugin();
+  }
+};

--- a/eos-icons/manifest.json
+++ b/eos-icons/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "eos-icons",
+  "id": "946743712584892439",
+  "api": "1.0.0",
+  "main": "code.js",
+  "ui": "ui.html"
+}

--- a/eos-icons/package-lock.json
+++ b/eos-icons/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "eos-icons",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@figma/plugin-typings": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.19.1.tgz",
+      "integrity": "sha512-hraStXkhLm76nSYmJMvZDHLrolvi2ii5IJd6JI6s/1Owzm2oT8PwnKHDHIMu/OBFxtK335w1ASARn6BmWcKShw==",
+      "dev": true
+    }
+  }
+}

--- a/eos-icons/package.json
+++ b/eos-icons/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "eos-icons",
+  "version": "1.0.0",
+  "description": "Your Figma plugin",
+  "main": "code.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "author": "",
+  "license": "",
+  "devDependencies": {
+    "@figma/plugin-typings": "^1.19.1"
+  }
+}

--- a/eos-icons/tsconfig.json
+++ b/eos-icons/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "typeRoots": [
+      "./node_modules/@types",
+      "./node_modules/@figma"
+    ]
+  }
+}

--- a/eos-icons/ui.html
+++ b/eos-icons/ui.html
@@ -1,0 +1,87 @@
+<link
+  rel="stylesheet"
+  href="https://cdn.jsdelivr.net/npm/eos-icons/dist/css/eos-icons.css"
+/>
+<style>
+  html,
+  body {
+    margin: 0;
+    padding: 0;
+    background-color: #e5e5e5;
+  }
+  #container {
+    width: 90%;
+    margin: auto;
+    margin-top: 10vh;
+  }
+  #search {
+    border: 1px solid #000;
+    display: block;
+    text-align: left;
+    width: 70%;
+    padding: 10px;
+  }
+  #submit {
+    width: 25%;
+  }
+  .flex-container {
+    display: flex;
+    justify-content: space-between;
+  }
+  .title {
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 24px;
+  }
+  #loading {
+    display: none;
+    padding-top: 1rem;
+  }
+</style>
+<div id="container">
+  <p class="title">EOS-icons</p>
+  <div class="flex-container">
+    <input id="search" placeholder="Search for an icon" />
+    <button id="submit">Search</button>
+  </div>
+  <p id="loading">Loading...</p>
+  <script>
+    document.getElementById("search").focus();
+    document.getElementById("submit").onclick = () => {
+      document.getElementById("loading").style.display = "initial";
+      const searchText = document.getElementById("search").value;
+      parent.postMessage(
+        { pluginMessage: { type: "search-icons", searchText } },
+        "*"
+      );
+    };
+    window.onmessage = async (event) => {
+      try {
+        if (event.data.pluginMessage.type === "get-svg") {
+          var request = new XMLHttpRequest();
+          var url =
+            "https://cors-anywhere.herokuapp.com/https://gitlab.com/SUSE-UIUX/eos-icons/-/raw/master/svg/" +
+            event.data.pluginMessage.searchText +
+            ".svg";
+          request.open("GET", url);
+          request.responseType = "document";
+          request.onload = () => {
+            const svg = new XMLSerializer().serializeToString(request.response);
+            parent.postMessage(
+              {
+                pluginMessage: {
+                  type: "handle-icon",
+                  svg: svg,
+                },
+              },
+              "*"
+            );
+            document.getElementById("loading").style.display = "none";
+          };
+          request.send();
+        }
+      } catch (e) {
+        console.log(e);
+      }
+    };
+  </script>
+</div>

--- a/eos-icons/ui.html
+++ b/eos-icons/ui.html
@@ -59,7 +59,7 @@
         if (event.data.pluginMessage.type === "get-svg") {
           var request = new XMLHttpRequest();
           var url =
-            "https://cors-anywhere.herokuapp.com/https://gitlab.com/SUSE-UIUX/eos-icons/-/raw/master/svg/" +
+            "https://cdn.jsdelivr.net/npm/eos-icons@latest/svg/" +
             event.data.pluginMessage.searchText +
             ".svg";
           request.open("GET", url);


### PR DESCRIPTION
I was able to get the plugin talking to the EOS-icons SVGs hosted on [GitLab](https://gitlab.com/SUSE-UIUX/eos-icons/-/tree/master/svg). GitLab doesn't allow cross-origin requests so I used a temp workaround for dev, we will need to figure something out in the future. Would love any suggestions you may have as to how I can access EOS-icon SVGs.

### What I plan to do next
- Stylize the frontend UI
- Make SVG access reliable
- Add a dynamic search functionality

https://user-images.githubusercontent.com/40818234/109178790-3d846100-77af-11eb-8b26-2285db3c39d6.mp4

