### PR TITLE
fix : added editor type in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,5 +3,9 @@
   "id": "946743712584892439",
   "api": "1.0.0",
   "main": "dist/code.js",
+  "editorType": [
+    "figma",
+    "figjam"
+  ],
   "ui": "dist/ui.html"
 }


### PR DESCRIPTION
This makes the plugin compatible with both figma & figJam

Closes #15