### PR TITLE
Allows forked repository to run workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [main]
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"

--- a/manifest.json
+++ b/manifest.json
@@ -3,9 +3,6 @@
   "id": "946743712584892439",
   "api": "1.0.0",
   "main": "dist/code.js",
-  "editorType": [
-    "figma",
-    "figjam"
-  ],
+  "editorType": ["figma", "figjam"],
   "ui": "dist/ui.html"
 }


### PR DESCRIPTION
## Allows forked repository to run workflow

**Motivation** : I have seen that, in [this](https://github.com/EOS-uiux-Solutions/eos-icons-figma/pull/16) pr, [build run fails](https://github.com/EOS-uiux-Solutions/eos-icons-figma/runs/5460620542?check_suite_focus=true) and since i was unable to run it on my forked repository, i didn't know about this issue unless it was merged by the maintainer.So, to fix that issue this PR has been made.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
